### PR TITLE
Fix/update rank name

### DIFF
--- a/genomeuploader/constants.py
+++ b/genomeuploader/constants.py
@@ -16,11 +16,11 @@
 
 HQ = (
     "Multiple fragments where gaps span repetitive regions. Presence of the "
-    "23S, 16S, and 5S rRNA genes and at least 18 tRNAs."
+    "23S, 16S, and 5S rRNA genes and at least 18 tRNAs"
 )
 MQ = (
     "Many fragments with little to no review of assembly other than reporting "
-    "of standard assembly statistics."
+    "of standard assembly statistics"
 )
 
 METAGENOMES = [

--- a/genomeuploader/genome_upload.py
+++ b/genomeuploader/genome_upload.py
@@ -268,7 +268,7 @@ def extract_Eukaryota_info(name, rank):
 def extract_Bacteria_info(name, rank):
     if rank == "species":
         name = name
-    elif rank == "superkingdom":
+    elif rank == "domain":
         name = "uncultured bacterium".format(name)
     elif rank in ["family", "order", "class", "phylum"]:
         name = "uncultured {} bacterium".format(name)
@@ -289,7 +289,7 @@ def extract_Bacteria_info(name, rank):
 def extract_Archaea_info(name, rank):
     if rank == "species":
         name = name
-    elif rank == "superkingdom":
+    elif rank == "domain":
         name = "uncultured archaeon"
     elif rank == "phylum":
         if "Euryarchaeota" in name:

--- a/genomeuploader/genome_upload.py
+++ b/genomeuploader/genome_upload.py
@@ -676,7 +676,7 @@ def write_genomes_xml(genomes, xml_path, genomeType, centreName, tpa):
         ["completeness software", "stats_generation_software"],
         ["completeness score", "completeness", "%"],
         ["contamination score", "contamination", "%"],
-        ["isolation source", "isolationSource"],
+        ["isolation_source", "isolationSource"],
         ["collection date", "collectionDate"],
         ["geographic location (country and/or sea)", "country"],
         ["geographic location (latitude)", "latitude", "DD"],


### PR DESCRIPTION
Fixes to match changes in ENA:

- The rank `superkingdom` is now called `domain`
- An underscore is now required in `isolation_source`
- Periods are no longer allowed at the end of the sentences in quality descriptions.