### PR TITLE
Bugfix/samples not matching mags privacy

### DIFF
--- a/genomeuploader/genome_upload.py
+++ b/genomeuploader/genome_upload.py
@@ -543,16 +543,18 @@ class GenomeUpload:
             collection_date = "missing: third party data"
         return collection_date
 
-    def get_location_metadata(self, sample_info):
-
-        latitude, longitude = "missing: third party data", "missing: third party data"
+def get_location_metadata(self, sample_info):
+        latitude = "missing: third party data"
+        longitude = "missing: third party data"
         country = "missing: third party data"
 
-        if self.private:
-            latitude = sample_info.get("latitude", "not provided")
-            longitude = sample_info.get("longitude", "not provided")
-            country = sample_info.get("country", "not provided")
-        else:
+        try:
+            # in this case, samples would be private
+            latitude = sample_info["latitude"]
+            longitude = sample_info["longitude"]
+            country = sample_info["country"]
+        except KeyError:
+            # samples are either public, or missing metadata
             try:
                 country = sample_info["country"].split(":")[0]
                 location = sample_info["location"]

--- a/genomeuploader/genome_upload.py
+++ b/genomeuploader/genome_upload.py
@@ -549,12 +549,12 @@ def get_location_metadata(self, sample_info):
         country = "missing: third party data"
 
         try:
-            # in this case, samples would be private
             latitude = sample_info["latitude"]
             longitude = sample_info["longitude"]
             country = sample_info["country"]
         except KeyError:
-            # samples are either public, or missing metadata
+            # trying other fields, as a different checklist might have 
+            # been used, or metadata might be missing
             try:
                 country = sample_info["country"].split(":")[0]
                 location = sample_info["location"]

--- a/genomeuploader/genome_upload.py
+++ b/genomeuploader/genome_upload.py
@@ -544,17 +544,15 @@ class GenomeUpload:
         return collection_date
 
     def get_location_metadata(self, sample_info):
-        latitude = "missing: third party data"
-        longitude = "missing: third party data"
+
+        latitude, longitude = "missing: third party data", "missing: third party data"
         country = "missing: third party data"
 
-        try:
-            # in this case, samples would be private
-            latitude = sample_info["latitude"]
-            longitude = sample_info["longitude"]
-            country = sample_info["country"]
-        except KeyError:
-            # samples are either public, or missing metadata
+        if self.private:
+            latitude = sample_info.get("latitude", "not provided")
+            longitude = sample_info.get("longitude", "not provided")
+            country = sample_info.get("country", "not provided")
+        else:
             try:
                 country = sample_info["country"].split(":")[0]
                 location = sample_info["location"]

--- a/genomeuploader/genome_upload.py
+++ b/genomeuploader/genome_upload.py
@@ -544,15 +544,17 @@ class GenomeUpload:
         return collection_date
 
     def get_location_metadata(self, sample_info):
-
-        latitude, longitude = "missing: third party data", "missing: third party data"
+        latitude = "missing: third party data"
+        longitude = "missing: third party data"
         country = "missing: third party data"
 
-        if self.private:
-            latitude = sample_info.get("latitude", "not provided")
-            longitude = sample_info.get("longitude", "not provided")
-            country = sample_info.get("country", "not provided")
-        else:
+        try:
+            # in this case, samples would be private
+            latitude = sample_info["latitude"]
+            longitude = sample_info["longitude"]
+            country = sample_info["country"]
+        except KeyError:
+            # samples are either public, or missing metadata
             try:
                 country = sample_info["country"].split(":")[0]
                 location = sample_info["location"]


### PR DESCRIPTION
It _may_ happen that samples used to inherit genomes metadata do not match the status of the genome submission. For example, it may happen that a user wants to submit private MAGs, but the original samples are in someone else's public project. As it was, the code was failing because it was only checking for private data structure in private submissions (in the following example, ERS20120889 is public).

```
Command error:
  INFO:genomeuploader.genome_upload:Retrieving data for MAG submission...
  INFO:genomeuploader.genome_upload:Retrieving info for genomes to submit...
  INFO:genomeuploader.genome_upload:Retrieving project and run info from ENA (this might take a while)...
  INFO:genomeuploader.ena:ERR13648026 private run returned from ENA
  INFO:genomeuploader.ena:ERP163940 private study returned from ENA
  ERROR:genomeuploader.ena:ERS20120889: Empty or missing response text.
...
```

This PR allows for more generic checks, independent from the submission status (private or public): it just checks how values are stored in the dictionary and inherits data accordingly.