### PR TITLE
add header to registered.tsv

### DIFF
--- a/genomeuploader/genome_upload.py
+++ b/genomeuploader/genome_upload.py
@@ -193,7 +193,6 @@ def save_accessions(alias_accession_dict: dict, accessions_file: Path):
     Args:
         alias_accession_dict (dict): Mapping of alias to accession.
         accessions_file (Path): Output file path.
-        write_mode (str): File write mode ('w', 'a', etc.).
     Returns:
         None
     """
@@ -868,7 +867,7 @@ class GenomeUpload:
 
         if len(alias_accession_map) == len(genome_info):
             # all genomes were registered
-            samples_to_save = alias_accession_map
+            save_accessions(alias_accession_map, self.accessions_file)
         else:
             if len(alias_accession_map) > 0:
                 # exclude those from XML
@@ -883,15 +882,13 @@ class GenomeUpload:
                 if len(new_alias_accession_map) == len(filtered_genome_info):
                     # all new genomes were registered
                     alias_accession_map.update(new_alias_accession_map)
-                    samples_to_save = alias_accession_map
+                    save_accessions(alias_accession_map, self.accessions_file)
                 else:
                     raise Exception("An error occurred during the registration step. "
                                     "Please, check submission_receipt_retry.xml file for details.")
             else:
                 raise Exception("Some genomes could not be submitted to ENA. "
                                 "Please, check the errors above and submission_receipt.xml file.")
-        save_accessions(samples_to_save, self.accessions_file)
-
         logger.info("Generating manifest files...")
 
         manifest_info = compute_manifests(genome_info)

--- a/genomeuploader/genome_upload.py
+++ b/genomeuploader/genome_upload.py
@@ -187,7 +187,7 @@ def combine_ena_info(genome_info: dict, ena_dict: dict):
         genome_info[g]["accessions"] = ",".join(genome_info[g]["accessions"])
 
 
-def save_accessions(alias_accession_dict: dict, accessions_file: Path, write_mode: str):
+def save_accessions(alias_accession_dict: dict, accessions_file: Path):
     """
     Saves alias-accession mappings to a file.
     Args:
@@ -197,7 +197,8 @@ def save_accessions(alias_accession_dict: dict, accessions_file: Path, write_mod
     Returns:
         None
     """
-    with accessions_file.open(write_mode) as f:
+    with open(accessions_file, 'w') as f:
+        f.write('alias\tsample\n')
         for elem in alias_accession_dict:
             f.write(f"{elem}\t{alias_accession_dict[elem]}\n")
 
@@ -867,7 +868,7 @@ class GenomeUpload:
 
         if len(alias_accession_map) == len(genome_info):
             # all genomes were registered
-            save_accessions(alias_accession_map, self.accessions_file, "w")
+            samples_to_save = alias_accession_map
         else:
             if len(alias_accession_map) > 0:
                 # exclude those from XML
@@ -881,14 +882,15 @@ class GenomeUpload:
                 new_alias_accession_map = ena_submit_new.handle_genomes_registration()
                 if len(new_alias_accession_map) == len(filtered_genome_info):
                     # all new genomes were registered
-                    save_accessions(new_alias_accession_map, self.accessions_file, "a")
                     alias_accession_map.update(new_alias_accession_map)
+                    samples_to_save = alias_accession_map
                 else:
                     raise Exception("An error occurred during the registration step. "
                                     "Please, check submission_receipt_retry.xml file for details.")
             else:
                 raise Exception("Some genomes could not be submitted to ENA. "
                                 "Please, check the errors above and submission_receipt.xml file.")
+        save_accessions(samples_to_save, self.accessions_file)
 
         logger.info("Generating manifest files...")
 

--- a/tests/test_genome_upload.py
+++ b/tests/test_genome_upload.py
@@ -46,8 +46,8 @@ class Tests:
         filepath = "tests/fixtures/bin_upload/registered_bins_test.tsv"
         with open(filepath, "r") as f:
             lines = f.readlines()
-        # should have the same number of genomes
-        assert len(lines) == number_of_bins
+        # should have the same number of genomes (including header)
+        assert len(lines) == number_of_bins + 1
         # should have sample id (ERS) and suffix from --test-suffix command
         assert "ERS" in "".join(lines) and "end-to-end" in "".join(lines)
 
@@ -109,8 +109,8 @@ class Tests:
         filepath = "tests/fixtures/bin_upload/registered_bins_test.tsv"
         with open(filepath, "r") as f:
             lines = f.readlines()
-        # should have 3 line
-        assert len(lines) == number_of_bins2
+        # should have 3 lines + header
+        assert len(lines) == number_of_bins2 + 1
         # Check sample count, XML should include only new genomes, excluding registered in first round
         with open("tests/fixtures/bin_upload/genome_samples.xml") as f:
             assert f.read().count("alias=") == number_of_bins2 - number_of_bins1


### PR DESCRIPTION
I need that header for seqsubmit. I think it would be good to have it in genome_uploader output.
I have also removed 'a' mode that can be annoying. 