### PR TITLE
Add checks and tests for unformatted collection_date

### DIFF
--- a/.github/workflows/pytest_workflow.yml
+++ b/.github/workflows/pytest_workflow.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, dev]
 
 jobs:
   pytest:

--- a/genomeuploader/constants.py
+++ b/genomeuploader/constants.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 HQ = "Multiple fragments where gaps span repetitive regions. Presence of the 23S, 16S, and 5S rRNA genes and at least 18 tRNAs"
 MQ = "Many fragments with little to no review of assembly other than reporting of standard assembly statistics"
 
@@ -655,3 +657,17 @@ BIN_CHECKLIST = "ERC000050"
 BIN_CHECKLIST_TYPE = "binned_metagenome"
 MAG_CHECKLIST = "ERC000047"
 MAG_CHECKLIST_TYPE = "Metagenome-assembled genome"
+
+# collection_date regex currently supported by ENA (last reviewed 27.04.2026)
+COLLECTION_DATE_REGEX = re.compile(r"(^[12][0-9]{3}(-(0[1-9]|1[0-2])(-(0[1-9]|[12][0-9]|3[01])(T[0-9]{2}:[0-9]{2}(:[0-9]{2})?Z?([+-][0-9]{1,2})?)?)?)?(/[0-9]{4}(-[0-9]{2}(-[0-9]{2}(T[0-9]{2}:[0-9]{2}(:[0-9]{2})?Z?([+-][0-9]{1,2})?)?)?)?)?$)")
+DATE_FORMATS = [
+    "%Y/%m/%d",      # 2009/7/17
+    "%d/%m/%Y",      # 17/7/2009
+    "%m/%d/%Y",      # 7/17/2009
+    "%d/%b/%Y",      # 21/Sep/2015
+    "%d/%B/%Y",      # 21/September/2015
+    "%m-%d-%Y",      # 7-17-2009
+    "%d-%m-%Y",      # 17-7-2009
+    "%d-%b-%Y",      # 21-Sep-2015
+    "%d-%B-%Y",      # 21-September-2015
+]

--- a/genomeuploader/genome_upload.py
+++ b/genomeuploader/genome_upload.py
@@ -32,6 +32,8 @@ from genomeuploader.constants import (
     BIN_CHECKLIST,
     BIN_CHECKLIST_TYPE,
     BIN_MANDATORY_FIELDS,
+    COLLECTION_DATE_REGEX,
+    DATE_FORMATS,
     GEOGRAPHIC_LOCATIONS,
     GEOGRAPHY_DIGIT_COORDS,
     HQ,
@@ -514,28 +516,45 @@ class GenomeUpload:
 
         return genome_info
 
+    def reformat_collection_date(self, date):
+        for format in DATE_FORMATS:
+            try:
+                new_date = dt.strptime(date, format)
+                return new_date.strftime("%Y-%m-%d")
+            except ValueError:
+                continue
+        return None
+
     def get_collection_date(self, collection_date):
-        if collection_date.lower() in [
-            "not collected",
-            "not provided",
-            "restricted access",
-            "missing: control sample",
-            "missing: sample group",
-            "missing: synthetic construct",
-            "missing: lab stock",
-            "missing: third party data",
-            "missing: data agreement established pre-2023",
-            "missing: endangered species",
-            "missing: human-identifiable",
-        ]:
-            collection_date = collection_date.lower()
-        if (
-                not collection_date
-                or collection_date.lower() == "missing"
-                or collection_date.lower() in ["not available", "na"]
-        ):
-            collection_date = "missing: third party data"
-        return collection_date
+        # check if given collection date respects the required ENA format
+        if COLLECTION_DATE_REGEX.match(collection_date):
+            if collection_date.lower() in [
+                "not collected",
+                "not provided",
+                "restricted access",
+                "missing: control sample",
+                "missing: sample group",
+                "missing: synthetic construct",
+                "missing: lab stock",
+                "missing: third party data",
+                "missing: data agreement established pre-2023",
+                "missing: endangered species",
+                "missing: human-identifiable",
+            ]:
+                collection_date = collection_date.lower()
+            if (
+                    not collection_date
+                    or collection_date.lower() == "missing"
+                    or collection_date.lower() in ["not available", "na"]
+            ):
+                collection_date = "missing: third party data"
+            return collection_date
+        else:
+            # try to reformat the date
+            new_collection_date = self.reformat_collection_date(collection_date)
+            if not new_collection_date:
+                raise IOError(f"Collection date {collection_date} could not be parsed.")
+            return new_collection_date
 
     def get_location_metadata(self, sample_info):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "genome_uploader"
-version = "2.5.1"
+version = "2.5.2"
 
 readme = "README.md"
 authors = [

--- a/tests/test_collection_date.py
+++ b/tests/test_collection_date.py
@@ -1,0 +1,27 @@
+import pytest
+from genomeuploader.genome_upload import GenomeUpload
+
+@pytest.fixture
+def genome_upload_instance():
+    # Minimal args for instantiation; adjust as needed for your class
+    args = {
+        "bins": False,
+        "live": False,
+        "private": False,
+        "tpa": False,
+        "centre_name": "",
+        "force": False,
+        "out": ".",
+        "upload_study": "",
+        "genome_info": "",
+        "test_suffix": None,
+        "verbose": False,
+    }
+    return GenomeUpload(args)
+
+@pytest.mark.parametrize("input_date,expected", [
+    ("01-13-2021", "2021-01-13"),
+    ("04/Jan/2010", "2010-01-04"),
+])
+def test_get_collection_date_reformat(genome_upload_instance, input_date, expected):
+    assert genome_upload_instance.get_collection_date(input_date) == expected


### PR DESCRIPTION
Here we go again.

We discovered that collection_date used to allow different values than what it allows nowadays. Added exceptions for this

Plus I realised that pytest doesn't always run (especially in cases like this where we are merging into a branch different than main/dev) - I enabled that