### PR TITLE
Restructure sample querying based on privacy

### DIFF
--- a/.github/workflows/pytest_workflow.yml
+++ b/.github/workflows/pytest_workflow.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, dev]
 
 jobs:
   pytest:

--- a/genomeuploader/genome_upload.py
+++ b/genomeuploader/genome_upload.py
@@ -572,6 +572,9 @@ class GenomeUpload:
                         longitude = longitude.split("E")[0].strip()
             except KeyError as e:
                 pass
+        except TypeError:
+            # if the dictionary is empty, the sample wasn't found in the private/public api
+            return None
 
         if latitude not in ["missing: third party data", "not provided"]:
             try:
@@ -589,7 +592,13 @@ class GenomeUpload:
 
         if country not in GEOGRAPHIC_LOCATIONS:
             country = "missing: third party data"
-        return latitude, longitude, country
+
+        metadata_dict = {
+            "latitude": latitude,
+            "longitude": longitude,
+            "country": country
+        }
+        return metadata_dict
 
     def get_project_description(self, s):
         ena_query = EnaQuery(s, "study", self.private)
@@ -599,12 +608,23 @@ class GenomeUpload:
             project_description = study_info["study_title"]
         return project_description
 
-    def get_sample_metadata(self, sample_accession):
-        ena_query = EnaQuery(sample_accession, "sample", self.private)
+    def get_metadata_with_privacy(self, sample_accession, privacy_status):
+        ena_query = EnaQuery(sample_accession, "sample", privacy_status)
         sample_info = ena_query.build_query()
-        latitude, longitude, country = self.get_location_metadata(sample_info)
-        collection_date = self.get_collection_date(sample_info["collection_date"])
-        return latitude, longitude, country, collection_date
+        metadata_dict = self.get_location_metadata(sample_info)
+        if metadata_dict:
+            metadata_dict["collection_date"] = self.get_collection_date(sample_info["collection_date"])
+            return metadata_dict
+        else:
+            return None
+
+    def get_sample_metadata(self, sample_accession):
+        metadata_dict = self.get_metadata_with_privacy(sample_accession, self.private)
+        # it may happen that the status of registered samples is different
+        # than runs/assemblies referenced in the input metadata
+        if not metadata_dict:
+            metadata_dict = self.get_metadata_with_privacy(sample_accession, not self.private)
+        return metadata_dict
 
     def extract_ena_info(self, genome_info: dict):
         """
@@ -663,14 +683,14 @@ class GenomeUpload:
                         study_descriptions[study_accession] = self.get_project_description(study_accession)
 
                     sample_accession = general_info.get("sample_accession")
-                    latitude, longitude, country, collection_date = self.get_sample_metadata(sample_accession)
+                    metadata_dict = self.get_sample_metadata(sample_accession)
 
                     temp_dict[acc] = {
                         "instrumentModel": instrument_model,
-                        "collectionDate": collection_date,
-                        "country": country,
-                        "latitude": latitude,
-                        "longitude": longitude,
+                        "collectionDate": metadata_dict["collection_date"],
+                        "country": metadata_dict["country"],
+                        "latitude": metadata_dict["latitude"],
+                        "longitude": metadata_dict["longitude"],
                         "projectDescription": study_descriptions[study_accession],
                         "study": study_accession,
                         "sampleAccession": sample_accession,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,18 +77,31 @@ def private_study_data():
 
 @pytest.fixture
 def public_run_data():
-    return {"run_accession": "ERR4918394", "sample_accession": "SAMEA7687881", "secondary_study_accession": "ERP125469"}
+    return {
+        "run_accession": "ERR4918394",
+        "sample_accession": "SAMEA7687881",
+        "secondary_study_accession": "ERP125469"
+    }
 
 
 #   private json only has ERS sample IDs
 @pytest.fixture
 def private_run_data():
-    return {"run_accession": "ERR4918394", "sample_accession": "ERS5444411", "secondary_study_accession": "ERP125469"}
+    return {
+        "run_accession": "ERR4918394",
+        "sample_accession": "ERS5444411",
+        "secondary_study_accession": "ERP125469"
+    }
 
 
 @pytest.fixture
 def public_sample_data():
-    return {"sample_accession": "SAMEA7687881", "collection_date": "2019-06-11", "country": "Norway", "location": "66.079905 N 12.587848 E"}
+    return {
+        "sample_accession": "SAMEA7687881",
+        "collection_date": "2019-06-11",
+        "country": "Norway",
+        "location": "66.079905 N 12.587848 E"
+    }
 
 
 #  private xml can only query with RS accession and lat and long are split
@@ -115,9 +128,17 @@ def private_assembly_info_xml(test_file_dir):
 
 @pytest.fixture
 def public_assembly_info_data():
-    return {"study_accession": "PRJEB71644", "sample_accession": "SAMEA114545946", "sampling_platform": 'ILLUMINA'}
+    return {
+        "study_accession": "PRJEB71644",
+        "sample_accession": "SAMEA114545946",
+        "sampling_platform": 'ILLUMINA'
+    }
 
 
 @pytest.fixture
 def private_assembly_info_data():
-    return {"study_accession": "ERP157889", "sample_accession": "SRS1254557", "sampling_platform": 'ILLUMINA'}
+    return {
+        "study_accession": "ERP157889",
+        "sample_accession": "SRS1254557",
+        "sampling_platform": 'ILLUMINA'
+    }

--- a/tests/test_different_privacy_with_samples.py
+++ b/tests/test_different_privacy_with_samples.py
@@ -1,0 +1,106 @@
+import json
+
+import pytest
+import responses
+
+from genomeuploader.ena import EnaQuery
+from genomeuploader.genome_upload import GenomeUpload
+from test_ena import read_json
+
+@pytest.fixture
+def genome_upload_public_instance(tmp_path):
+    args = {
+        "bins": True,
+        "live": False,
+        "private": False,
+        "tpa": False,
+        "centre_name": "EMG",
+        "force": False,
+        "out": str(tmp_path),
+        "upload_study": "ERP000000",
+        "genome_info": str(tmp_path / "genome_info.tsv"),
+        "test_suffix": None,
+        "verbose": False,
+    }
+    return GenomeUpload(args)
+
+@pytest.fixture
+def genome_upload_private_instance(tmp_path):
+    args = {
+        "bins": True,
+        "live": False,
+        "private": True,
+        "tpa": False,
+        "centre_name": "EMG",
+        "force": False,
+        "out": str(tmp_path),
+        "upload_study": "ERP000000",
+        "genome_info": str(tmp_path / "genome_info.tsv"),
+        "test_suffix": None,
+        "verbose": False,
+    }
+    return GenomeUpload(args)
+
+@responses.activate
+def test_all_public_get_metadata_with_privacy_success(genome_upload_public_instance):
+    sample_accession = "SAMN00000001"
+    responses.add(
+        responses.POST,
+        "https://www.ebi.ac.uk/ena/portal/api/search",
+        json=[{
+            "sample_accession": sample_accession,
+            "collection_date": "2022-01-01",
+            "country": "France",
+            "location": "48.8566 N 2.3522 E"
+        }]
+    )
+
+    metadata = genome_upload_public_instance.get_metadata_with_privacy(sample_accession, privacy_status=False)
+    assert metadata["country"] == "France"
+    assert metadata["latitude"].startswith("48.85")
+    assert metadata["longitude"].startswith("2.35")
+    assert metadata["collection_date"] == "2022-01-01"
+
+@responses.activate
+def test_get_metadata_with_privacy_missing_fields(genome_upload_public_instance):
+    # Mock ENA sample API response with missing fields
+    sample_accession = "SAMN00000002"
+    responses.add(
+        responses.POST,
+        "https://www.ebi.ac.uk/ena/portal/api/search",
+        json=[{
+            "sample_accession": sample_accession,
+            "collection_date": "",
+            "country": "",
+            "location": ""
+        }]
+    )
+
+    metadata = genome_upload_public_instance.get_metadata_with_privacy(sample_accession, privacy_status=False)
+
+    assert metadata["country"] == "missing: third party data"
+    assert metadata["latitude"] == "missing: third party data"
+    assert metadata["longitude"] == "missing: third party data"
+    assert metadata["collection_date"] == "missing: third party data"
+
+@responses.activate
+def test_get_sample_metadata_private_submission_public_sample(monkeypatch, genome_upload_private_instance, public_sample_data):
+    # Simulate first privacy attempt returns None, second returns valid data
+    def emulate_get_metadata_with_privacy(accession, privacy_status):
+        if privacy_status is False:
+            return None
+        else:
+            metadata_dict = genome_upload_private_instance.get_location_metadata(public_sample_data)
+            if metadata_dict:
+                metadata_dict["collection_date"] = genome_upload_private_instance.get_collection_date(public_sample_data["collection_date"])
+                return metadata_dict
+            else:
+                return None
+
+    monkeypatch.setattr(genome_upload_private_instance, "get_metadata_with_privacy", emulate_get_metadata_with_privacy)
+    metadata = genome_upload_private_instance.get_sample_metadata("SAMEA7687881")
+
+    assert metadata["country"] == "Norway"
+    assert metadata["latitude"].startswith("66.07")
+    assert metadata["longitude"].startswith("12.58")
+    assert metadata["collection_date"] == "2019-06-11"


### PR DESCRIPTION
Addition to the previous privacy edit. Whenever a sample is queried, the query is built differently depending on private/public. I made sure to re-build the EnaQuery object whenever the sample is not found in the private or public api. 

And I wanted the test workflow here too